### PR TITLE
Debug patch for cloudStatus() wrong index access.

### DIFF
--- a/src/screens/WeatherDetailScreen.js
+++ b/src/screens/WeatherDetailScreen.js
@@ -46,7 +46,7 @@ export default class WeatherDetailScreen extends React.Component {
             'Overcast'
         ];
 
-        const text = (clouds === null) ? 'Null' : cloudStatus[Math.max(parseInt(clouds / 20), 4)];
+        const text = (clouds === null) ? 'Null' : cloudStatus[Math.min(parseInt(clouds / 20), 4)];
 
         return (
             <Text>Sky: {text}</Text>


### PR DESCRIPTION
Using `Math.min` will make the function operate as intended to set an upper bound for possible index number candidates.